### PR TITLE
fix ROCm/HIP support for large memory allocation.

### DIFF
--- a/examples/cuda_graph.py
+++ b/examples/cuda_graph.py
@@ -81,23 +81,23 @@ def run():
     print('torch.cuda.empty_cache()')
     torch.cuda.empty_cache()
 
-    print('sleep...')
+    print('before sleep...')
     time.sleep(3)
 
     print('call memory_saver.pause')
     memory_saver.pause()
 
-    print('sleep...')
+    print('after sleep...')
     time.sleep(3)
 
     print('when kv cache is released, we can allocate *other* big tensors')
     other_big_tensor = torch.zeros((2500_000_000,), dtype=torch.uint8, device='cuda')
-    print('sleep...')
+    print('before kv cache is released, sleep...')
     time.sleep(3)
     print(f'{other_big_tensor=}')
     del other_big_tensor
     torch.cuda.empty_cache()
-    print('sleep...')
+    print('after kv cache is released, sleep...')
     time.sleep(3)
 
     # this should fail
@@ -119,7 +119,7 @@ def run():
     print(f'{static_output=}')
     assert static_output == 202, f'{static_output=}'
 
-    print('sleep...')
+    print('after replay #2, sleep...')
     time.sleep(3)
 
     # print(f'{big_tensor=}')

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -10,24 +10,22 @@ from torch_memory_saver import TorchMemorySaver
 
 memory_saver = TorchMemorySaver()
 
-normal_tensor = torch.full((1_000_000_000,), 100, dtype=torch.uint8, device='cuda')
+normal_tensor = torch.full((4_000_000_000,), 100, dtype=torch.uint8, device='cuda')
 
 with memory_saver.region():
-    pauseable_tensor = torch.full((1_000_000_000,), 100, dtype=torch.uint8, device='cuda')
+    pauseable_tensor = torch.full((4_000_000_000,), 100, dtype=torch.uint8, device='cuda')
 
 print(f'{normal_tensor=} {pauseable_tensor=}')
 
-print('sleep...')
-time.sleep(3)
+print('before sleep...')
+time.sleep(10)
 
 memory_saver.pause()
-
-print('sleep...')
-time.sleep(3)
+print('after sleep...')
+time.sleep(10)
 
 memory_saver.resume()
-
-print('sleep...')
-time.sleep(3)
+print('resume from sleep...')
+time.sleep(10)
 
 print(f'{normal_tensor=} {pauseable_tensor=}')


### PR DESCRIPTION
Due to internal constraints in ROCm/HIP, virtual-memory allocation must be performed chunk-wise for large memory allocation. In addition, avoid using ROCm 6.4.0, an internal bug prevents memory from being released. This commit follows the approach introduced in https://github.com/vllm-project/vllm/pull/12695.